### PR TITLE
Use more reliable date comparison for invoice-type rates.

### DIFF
--- a/src/BNRExchangeHistory.ts
+++ b/src/BNRExchangeHistory.ts
@@ -39,7 +39,7 @@ export default new class BNRExchangeHistory {
             moment.subtract(i, 'days');
             const day = year.getDay(moment.toDate());
 
-            if (invoice && moment.toDate().toDateString() === date.toDateString()) {
+            if (invoice && moment.isSame(date, 'day')) {
                 continue;
             }
 


### PR DESCRIPTION
Use Moment.js [`isSame()`](https://momentjs.com/docs/#/query/is-same/) utility for comparing days instead of Node's built-in date output.

This should hopefully prevent different time zones from affecting invoice conversion rates and may be related to the issue mentioned in #1.